### PR TITLE
fix: resolve for `new Worker(new URL("data:..."))`

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -6,6 +6,7 @@ const baseURL = pathToFileURL(`${process.cwd()}/`).href
 const isWindows = process.platform === "win32"
 
 const extensionsRegex = /\.ts$/
+const dataUrlRegex = /^data:/
 
 export function resolve(specifier, context, defaultResolve) {
   const { parentURL = baseURL } = context
@@ -15,11 +16,15 @@ export function resolve(specifier, context, defaultResolve) {
     return { url }
   }
 
-  // try resolve `.ts` extension
-  let url = new URL(specifier + '.ts', parentURL).href 
-  const path = fileURLToPath(url)
-  if (fs.existsSync(path)) {
-    return { url }
+  // Using `new Worker(new URL("data:..."))` resolves a data URL which can't be
+  // passed to fileURLToPath()
+  if (!dataUrlRegex.test(specifier)) {
+    // Try to resolve `.ts` extension
+    let url = new URL(specifier + '.ts', parentURL).href
+    const path = fileURLToPath(url)
+    if (fs.existsSync(path)) {
+      return { url }
+    }
   }
 
   // Let Node.js handle all other specifiers.


### PR DESCRIPTION
Hi I ran into an issue where my worker thread was throwing `TypeError: The URL must be of scheme file` _only_ when using this Node loader. I knew it wasn't esbuild because `esbuild file.ts | node --input-type=module -` worked fine.

I added logs to the `resolve` hook to show when it passes to Node's resolver. Turns out `new Worker(new URL(...))` calls the resolve hook and this breaks because `filePathToUrl()` is used.

Here's an example. Console logs were placed in loader.mjs:

```ts
import { Worker } from 'worker_threads';
import { URL } from 'url';
const worker = new Worker(new URL('data:text/javascript,console.log(100)'));
worker.on('online', () => {
  console.log('Worker started');
});
worker.on('error', (err) => {
  console.log(`Worker error: ${err}`);
});
```

```
> node --no-warnings --experimental-loader esbuild-node-loader file.ts
resolve file:///home/today/_/work/haptic/file.ts
resolve worker_threads
resolved default
resolve url
resolved default
Worker started
resolve data:text/javascript,console.log(100)
Worker error: TypeError: The URL must be of scheme file
```