### PR TITLE
test: add test for TDD example

### DIFF
--- a/test/entry.ts
+++ b/test/entry.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
+import { relative } from 'path'
 import { test } from 'uvu'
 import execa from 'execa'
-import { relative } from 'path'
 
 const cwd = process.cwd()
 function relativize(path: string) {
@@ -58,6 +58,15 @@ test('import type module', async() => {
     '--experimental-loader',
     relativize(`${cwd}/loader.mjs`),
     relativize(`${cwd}/test/import-mjs/index.js`),
+  ])
+  assert(stdout === 'foo')
+})
+
+test('import folder', async() => {
+  const { stdout } = await execa('node', [
+    '--experimental-loader',
+    relativize(`${cwd}/loader.mjs`),
+    relativize(`${cwd}/test/folders/index.ts`),
   ])
   assert(stdout === 'foo')
 })

--- a/test/folders/graphql/anotherTest.ts
+++ b/test/folders/graphql/anotherTest.ts
@@ -1,0 +1,1 @@
+export const cool = 'coolTest'

--- a/test/folders/graphql/index.ts
+++ b/test/folders/graphql/index.ts
@@ -1,0 +1,2 @@
+export * from './test'
+export * from './anotherTest'

--- a/test/folders/graphql/test.ts
+++ b/test/folders/graphql/test.ts
@@ -1,0 +1,1 @@
+export const test = 'TEST'

--- a/test/folders/index.ts
+++ b/test/folders/index.ts
@@ -1,0 +1,2 @@
+import * as types from './graphql'
+const b = types


### PR DESCRIPTION
this adds an failing test for example purposes.
I want to use this as a custom loader for typescript files. But it fails caused by "folder imports"
Regarding the following article, it should work with `--experimental-specifier-resolution=node`
https://stackoverflow.com/a/65588027

Sadly it does not work. 
@antfu any idea how this is supposed to work?