### PR TITLE
fix: target node version instead of esnext

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -53,7 +53,7 @@ export function transformSource(source, context, defaultTransformSource) {
       sourcefile: filename,
       sourcemap: 'both',
       loader: 'ts',
-      target: 'esnext',
+      target: `node${process.versions.node}`,
       format: format === 'module' ? 'esm' : 'cjs',
     })
 

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -35,6 +35,15 @@ test('register3', async() => {
   assert(stdout === 'export')
 })
 
+test('register4', async() => {
+  const { stdout } = await execa('node', [
+    '--experimental-loader',
+    relativize(`${cwd}/loader.mjs`),
+    relativize(`${cwd}/test/fixture.optionalChaining.ts`),
+  ])
+  assert(stdout === 'hello from ts')
+})
+
 test('register cjs', async() => {
   const { stdout } = await execa('node', [
     '--experimental-loader',

--- a/test/fixture.optionalChaining.ts
+++ b/test/fixture.optionalChaining.ts
@@ -1,0 +1,4 @@
+const foo = {bar:"baz"}
+if(foo?.bar) {
+    console.log('hello from ts')
+}


### PR DESCRIPTION
otherwise it fails when using optional chaining with node12, see added testcase