### PR TITLE
feat: support importing with query

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -33,8 +33,8 @@ export function resolve(specifier, context, defaultResolve) {
 export function getFormat(url, context, defaultGetFormat) {
   if (extensionsRegex.test(new URL(url).pathname)) {
     return {
-      format: "module",
-    };
+      format: 'module',
+    }
   }
 
   // Let Node.js handle all other URLs.

--- a/loader.mjs
+++ b/loader.mjs
@@ -9,20 +9,20 @@ const extensionsRegex = /\.ts$/
 const excludeRegex = /^\w+:/
 
 export function resolve(specifier, context, defaultResolve) {
-  const { parentURL = baseURL } = context
-
-  if (extensionsRegex.test(specifier)) {
-    const url = new URL(specifier, parentURL).href
-    return { url }
+  const { parentURL = baseURL } = context;
+  const url = new URL(specifier, parentURL);
+  if (extensionsRegex.test(url.pathname)) {
+    return { url: url.href };
   }
 
   // ignore `data:` and `node:` prefix etc.
-  if (!excludeRegex.test(specifier)) {
+  if (!excludeRegex.test(url.pathname)) {
     // Try to resolve `.ts` extension
-    let url = new URL(specifier + '.ts', parentURL).href
-    const path = fileURLToPath(url)
+    url.pathname = url.pathname + '.ts';
+    // let url = new URL(pathname + ".ts", parentURL).href;
+    const path = fileURLToPath(url.href);
     if (fs.existsSync(path)) {
-      return { url }
+      return { url: url.href };
     }
   }
 
@@ -31,10 +31,10 @@ export function resolve(specifier, context, defaultResolve) {
 }
 
 export function getFormat(url, context, defaultGetFormat) {
-  if (extensionsRegex.test(url)) {
+  if (extensionsRegex.test(new URL(url).pathname)) {
     return {
-      format: 'module',
-    }
+      format: "module",
+    };
   }
 
   // Let Node.js handle all other URLs.

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -71,4 +71,13 @@ test('import type module', async() => {
   assert(stdout === 'foo')
 })
 
+test('import with query', async() => {
+  const { stdout } = await execa('node', [
+    '--experimental-loader',
+    relativize(`${cwd}/loader.mjs`),
+    relativize(`${cwd}/test/fixture.importWithQuery.ts`),
+  ])
+  assert(stdout === "1\n2");
+})
+
 test.run()

--- a/test/fixture.importWithQuery.ts
+++ b/test/fixture.importWithQuery.ts
@@ -1,0 +1,6 @@
+// Even if you use a query, it will be imported.
+import './fixture.query?1';
+// If the query is different, it will be loaded.
+import './fixture.query?2';
+// If the query is the same, the cached result will be used.
+import './fixture.query?2';

--- a/test/fixture.query.ts
+++ b/test/fixture.query.ts
@@ -1,0 +1,3 @@
+import { URL } from 'url';
+
+console.log(new URL(import.meta.url).search.slice(1));


### PR DESCRIPTION
I fixed the behavior when importing with query parameters.

- When imported with query parameters, it will be imported as a separate module.
- Importing with the same query parameters will use the cache.

#### Additional Context

I referred to the behavior in Deno.

[Deno Source -- Gist](https://gist.github.com/kamiazya/77857007cc62e0192fc78701e1d62304)

```bash
$ deno run https://gist.githubusercontent.com/kamiazya/77857007cc62e0192fc78701e1d62304/raw/6826ea6cfc008844e37a42988d90e188b4514395/fixture.importWithQuery.ts
1
2
```
