### PR TITLE
fix: fix exclude degradation

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -16,7 +16,7 @@ export function resolve(specifier, context, defaultResolve) {
   }
 
   // ignore `data:` and `node:` prefix etc.
-  if (!excludeRegex.test(url.pathname)) {
+  if (!excludeRegex.test(specifier)) {
     // Try to resolve `.ts` extension
     url.pathname = url.pathname + '.ts';
     // let url = new URL(pathname + ".ts", parentURL).href;

--- a/test/fixture.cjs.ts
+++ b/test/fixture.cjs.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'node:fs'
 
 if (typeof fs.readFileSync === 'function')
   console.log('fs imported')


### PR DESCRIPTION
Sorry, #13 is degrating the features of #3.

And the error in #2 was due to a specification such as `node:fs`.

fix #2
