### PR TITLE
fix: use esbuild when module import with query

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -44,7 +44,7 @@ export function getFormat(url, context, defaultGetFormat) {
 export function transformSource(source, context, defaultTransformSource) {
   const { url, format } = context
 
-  if (extensionsRegex.test(url)) {
+  if (extensionsRegex.test(new URL(url).pathname)) {
     let filename = url
     if (!isWindows)
       filename = fileURLToPath(url)

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -89,6 +89,15 @@ test('import tsx', async() => {
   assert(stdout === 'foo:bar')
 })
 
+test('import tsx2', async() => {
+  const { stdout } = await execa('node', [
+    '--experimental-loader',
+    relativize(`${cwd}/loader.mjs`),
+    relativize(`${cwd}/test/fixture.query2.ts`),
+  ])
+  assert(stdout === 'foo:bar')
+})
+
 test('import json', async() => {
   const { stdout } = await execa('node', [
     '--experimental-loader',

--- a/test/fixture.query2.ts
+++ b/test/fixture.query2.ts
@@ -1,0 +1,1 @@
+import './fixture.tsxStyle.tsx?query'


### PR DESCRIPTION
#13 was incomplete, so I fixed it.

### What was the problem

When importing with a query like `test/fixture.query2.ts`, the `context.url` given to the `transformSource` function will be like `"/path/to/test/fixture.tsxStyle.tsx?query"` and match `extensionsRegex` and the build with esbuild is not done.
