### PR TITLE
fix esbuild version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "node --experimental-loader ./loader.mjs test/entry.ts"
   },
   "dependencies": {
-    "esbuild": "^0.13.12"
+    "esbuild": ">=0.14.11"
   },
   "peerDependencies": {
     "typescript": "^4.0"


### PR DESCRIPTION
fix esbuild version.

when I use esmo, I met this issue:https://github.com/evanw/esbuild/issues/1807

but esmo depend on esbuild-node-loader.