### PR TITLE
fix: obsolete loader hook warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "esbuild": ">=0.13.12",
-    "node-fetch": "^3.2.1"
+    "node-fetch": "^3.2.1",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,12 +9,14 @@ specifiers:
   eslint: ^8.10.0
   execa: ^6.1.0
   node-fetch: ^3.2.1
+  semver: ^7.3.5
   typescript: ^4.6.2
   uvu: ^0.5.3
 
 dependencies:
   esbuild: 0.14.25
   node-fetch: 3.2.1
+  semver: 7.3.5
 
 devDependencies:
   '@antfu/eslint-config': 0.16.1_eslint@8.10.0+typescript@4.6.2
@@ -1789,7 +1791,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2194,7 +2195,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2487,7 +2487,6 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml-eslint-parser/0.5.0:
     resolution: {integrity: sha512-nJeyLA3YHAzhBTZbRAbu3W6xrSCucyxExmA+ZDtEdUFpGllxAZpto2Zxo2IG0r0eiuEiBM4e+wiAdxTziTq94g==}


### PR DESCRIPTION
Fix `DeprecationWarning: Obsolete loader hook(s) supplied and will be ignored: getFormat, getSource, transformSource`
